### PR TITLE
Make all images use absolute URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://michellelim.dev"
 languageCode = "en-us"
 title = "Michelle Lim"
 theme = "ezhil"

--- a/content/writing/into-the-fediverse.md
+++ b/content/writing/into-the-fediverse.md
@@ -3,7 +3,7 @@ title: "Into the Fediverse"
 date: 2021-06-26T23:10:43-04:00
 description: "Social media apps should share the same social graph by implementing ActivityPub"
 images:
-  ["https://michellelim.dev/images/anti-facebook.png"]
+  ["/images/anti-facebook.png"]
 type: "post"
 ---
 ## Social media apps should share the same social graph by implementing ActivityPub


### PR DESCRIPTION
Twitter cards weren't showing because the meta tags weren't using absolute URL.
It turns out that hugo is using `{{ index . 0 | absURL }}` to create an absolute URL.
The problem was that I hadn't set `baseURL` yet and so it didn't create the absolute URL.
Setting `baseURL` should now allow all my Twitter cards to show.