### PR TITLE
Fix baseURL to fix css

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://michellelim.dev"
+baseURL = "https://michellelim.dev/"
 languageCode = "en-us"
 title = "Michelle Lim"
 theme = "ezhil"


### PR DESCRIPTION
The deployed site's CSS paths were missing a slash. It turns out that you have to manually add it to your `baseURL`. It is not cool that the local build did not catch this problem. 
<img width="1051" alt="image" src="https://user-images.githubusercontent.com/24448704/236364721-d6a2116b-0b9b-4754-976b-413e0caa32ed.png">
